### PR TITLE
[COOK-1169] python::pip recipe failure because it's looking for Python in the wrong directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,16 @@
 #
 
 default['python']['install_method'] = 'package'
-default['python']['prefix_dir'] = '/usr/local'
+
+if python['install_method'] == 'package'
+  default['python']['prefix_dir'] = '/usr'
+else
+  default['python']['prefix_dir'] = '/usr/local'
+end
+
 default['python']['url'] = 'http://www.python.org/ftp/python'
 default['python']['version'] = '2.7.1'
 default['python']['checksum'] = '80e387bcf57eae8ce26726753584fd63e060ec11682d1145af921e85fd612292'
 default['python']['configure_options'] = %W{--prefix=#{python['prefix_dir']}}
+
+default['python']['pip']['prefix_dir'] = '/usr/local'

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -18,7 +18,8 @@
 # limitations under the License.
 #
 
-python_bindir = "#{node['python']['prefix_dir']}/bin/"
+python_bindir = "#{node['python']['prefix_dir']}/bin"
+pip_bindir    = "#{node['python']['pip']['prefix_dir']}/bin"
 
 # Ubuntu's python-setuptools, python-pip and python-virtualenv packages
 # are broken...this feels like Rubygems!
@@ -27,14 +28,14 @@ python_bindir = "#{node['python']['prefix_dir']}/bin/"
 remote_file "#{Chef::Config[:file_cache_path]}/distribute_setup.py" do
   source "http://python-distribute.org/distribute_setup.py"
   mode "0644"
-  not_if { ::File.exists?(python_bindir+'pip') }
+  not_if { ::File.exists?("#{pip_bindir}/pip") }
 end
 
 bash "install-pip" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
-  #{python_bindir}python distribute_setup.py
-  #{python_bindir}easy_install pip
+  #{python_bindir}/python distribute_setup.py
+  #{pip_bindir}/easy_install pip
   EOF
-  not_if { ::File.exists?(python_bindir+'pip') }
+  not_if { ::File.exists?("#{pip_bindir}/pip") }
 end


### PR DESCRIPTION
Separated Python and pip's `prefix_dir` so that the installation of pip can complete when `install_method` is `package`.
