### PR TITLE
Catch exception when pip not already installed 

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -126,7 +126,7 @@ def current_installed_version
     end
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
-  else
+  rescue
   end
 end
 


### PR DESCRIPTION
When pip is not already installed, `current_installed_version`
throws an uncaught `Mixlib::ShellOut::ShellCommandFailed`. It tries
to catch a `Chef::Exceptions::ShellCommandFailed`, but that doesn't
work. This patch makes it unconditionally return `nil` if an exception
occurs, so that pip can be installed properly.

There's probably a better way to fix this, but alas, I am not
well-versed in Ruby.
