### PR TITLE
Fix shell_out exception capturing

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -127,6 +127,7 @@ def current_installed_version
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
   rescue Chef::Exceptions::ShellCommandFailed
+  rescue Mixlib::ShellOut::ShellCommandFailed
   end
 end
 


### PR DESCRIPTION
When  "pip freeze | grep -i '^#{package_name}=='" returns no packages
grep returns 1.

This is Mixlib:ShellOut:ShellCommandFailed exception, rather than
Chef:Exceptions:ShellCommandFailed.

However, I am not really sure whether we should fix this in this cookbook or mixlib.
