### PR TITLE
COOK-1282: python cookbook wasn't rescuing the right exception

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -126,6 +126,8 @@ def current_installed_version
     end
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
+
+  rescue Chef::Exceptions::ShellCommandFailed
   rescue Mixlib::ShellOut::ShellCommandFailed
   end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1282
