### PR TITLE
Fix cookbook in 0.10.10

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -22,7 +22,7 @@ require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
 include Chef::Mixin::ShellOut
 
-# the logic in all action methods mirror that of
+# the logic in all action methods mirror that of 
 # the Chef::Provider::Package which will make
 # refactoring into core chef easy
 
@@ -40,7 +40,7 @@ action :install do
   if @new_resource.timeout
     timeout = @new_resource.timeout
   end
-
+  
   if install_version
     Chef::Log.info("Installing #{@new_resource} version #{install_version}")
     status = install_package(@new_resource.package_name, install_version, timeout)
@@ -98,26 +98,26 @@ def expand_options(options)
   options ? " #{options}" : ""
 end
 
-# these methods are the required overrides of
-# a provider that extends from Chef::Provider::Package
+# these methods are the required overrides of 
+# a provider that extends from Chef::Provider::Package 
 # so refactoring into core Chef should be easy
 
 def load_current_resource
   @current_resource = Chef::Resource::PythonPip.new(@new_resource.name)
   @current_resource.package_name(@new_resource.package_name)
   @current_resource.version(nil)
-
+  
   unless current_installed_version.nil?
     @current_resource.version(current_installed_version)
   end
-
+  
   @current_resource
 end
 
 def current_installed_version
   @current_installed_version ||= begin
     delimeter = /==/
-
+    
     version_check_cmd = "#{pip_cmd(@new_resource)} freeze | grep -i '^#{@new_resource.package_name}=='"
     # incase you upgrade pip with pip!
     if @new_resource.package_name.eql?('pip')
@@ -126,14 +126,17 @@ def current_installed_version
     end
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
-  rescue Chef::Exceptions::ShellCommandFailed
-  end
+
+    rescue Chef::Exceptions::ShellCommandFailed
+    rescue Mixlib::ShellOut::ShellCommandFailed
+    rescue NameError
+    end
 end
 
 def candidate_version
   @candidate_version ||= begin
     # `pip search` doesn't return versions yet
-    # `pip list` may be coming soon:
+    # `pip list` may be coming soon: 
     # https://bitbucket.org/ianb/pip/issue/197/option-to-show-what-version-would-be
     @new_resource.version||'latest'
   end
@@ -156,11 +159,5 @@ end
 # TODO remove when provider is moved into Chef core
 # this allows PythonPip to work with Chef::Resource::Package
 def pip_cmd(nr)
-  if (nr.respond_to?("virtualenv") && nr.virtualenv)
-    ::File.join(nr.virtualenv,'/bin/pip')
-  elsif "#{node['python']['install_method']}".eql?("source")
-    ::File.join("#{node['python']['prefix_dir']}","/bin/pip")
-  else
-    'pip'
-  end
+  (nr.respond_to?("virtualenv") && nr.virtualenv) ? ::File.join(nr.virtualenv,'/bin/pip') : 'pip'
 end


### PR DESCRIPTION
Mixlib::ShellOut::ShellCommandFailed doesn't exist in 0.10.8 so we have to handle that name error and include Chef::Exceptions::ShellCommandFailed which is how 0.10.8 does it.

Tested on both 0.10.8 and 0.10.10.
