### PR TITLE
Changes to ensure cookbook works in both 0.10.8 and 0.10.10

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -127,6 +127,8 @@ def current_installed_version
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
   rescue Chef::Exceptions::ShellCommandFailed
+  rescue Mixlib::ShellOut::ShellCommandFailed
+  rescue NameError
   end
 end
 


### PR DESCRIPTION
Just the changes needed this time - sorry about the oversight in the last request.

rescue Mixlib::ShellOut::ShellCommandFailed is new in 0.10.10
rescue Chef::Exceptions::ShellCommandFailed is required by 0.10.8
rescue NameError handles the missing Mixlib::ShellOut::ShellCommandFailed for 0.10.8.
