### PR TITLE
COOK-1320 catch correct exception

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -126,7 +126,7 @@ def current_installed_version
     end
     p = shell_out!(version_check_cmd)
     p.stdout.split(delimeter)[1].strip
-  rescue Chef::Exceptions::ShellCommandFailed
+  rescue Chef::Exceptions::ShellCommandFailed, Mixlib::ShellOut::ShellCommandFailed
   end
 end
 


### PR DESCRIPTION
Fix for COOK-1320. It seems the latest chef-client code throws a different exception
