### PR TITLE
COOK-1415 Changing default Python interpreter to a more generic 'python'

### DIFF
--- a/resources/virtualenv.rb
+++ b/resources/virtualenv.rb
@@ -21,7 +21,7 @@
 actions :create, :delete
 
 attribute :path, :kind_of => String, :name_attribute => true
-attribute :interpreter, :default => 'python2.6'
+attribute :interpreter, :default => 'python'
 attribute :owner, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
 attribute :options, :kind_of => String


### PR DESCRIPTION
In the python Cookbook there seems to be a contention in version usage:

A. The Attribute ['python']['version'] in https://github.com/opscode-cookbooks/python/blob/master/attributes/default.rb#L39
B. The Attribute :interpreter in https://github.com/opscode-cookbooks/python/blob/master/resources/virtualenv.rb#L24

Should the python_virtualenv Resource honor the the Cookbook's Default Attribute?

Per a conversation on #chef-hacking:

```
<ampledata 10:37> lets talk about http://tickets.opscode.com/browse/COOK-1415
<jtimberman 10:42> what about it?
<ampledata 10:42> you said ping you to discuss
<jtimberman 10:42> ok :)
<ampledata 10:42> what do you think, should that resource be changed to use the cookbook's attribute
<jtimberman 10:42> no
<jtimberman 10:42> not in the resources file
<jtimberman 10:42> because the attribute might not be available there
<jtimberman 10:43> due to the order in which the compoents of a cookbook are loaded.
<ampledata 10:43> ok, should we even propagate the version from the attributes to the resource at all
<ampledata 10:43> whatever method that might be
<ampledata 10:43> it just seems wrong to have two different defaults set
<jtimberman 10:43> ampledata: if you want to do that in your own recipe using the resource, then you can have it
<jtimberman 10:43> er have at it
<jtimberman 10:44> brb
<ampledata 10:45> so the root of why i'm asking is this: https://github.com/opscode-cookbooks/application_python/blob/master/providers/django.rb#L98
<ampledata 10:45> the django resource calls python_virtualenv, without passing a python version. the default python version for python_virtualenv is 2.6, the default python version for the python cookbook is 2.7.1
<ampledata 10:46> maybe we should change the default python version for python_virtualenv to 2.7.1 to match the cookbook
<hoover_damm 10:59> ampledata, isn't 2.6 only for centos?
<hoover_damm 10:59> and it should be 2.7.x for non el*
<ampledata 11:03> idk, don't use centos
<ampledata 11:03> ubuntu 1204 ships with 2.7
<ampledata 11:03> and the much older version of the python cookbook we'd been using ships with 2.7.1 as the default
<ampledata 11:04> i guess i don't care as much what the default is, as long as it's consistent
<jtimberman 11:10> ampledata: well
<jtimberman 11:10> ampledata: what is the python binary going to be called?
<jtimberman 11:10> is it just python?
<hoover_damm 11:11> 12.04 ships with 2.7 + 3.2
<jtimberman 11:11> sure
<jtimberman 11:11> so perhaps, if anything, the interpreter attribute in the resource should be 'python' and not 'python26' ?
<ampledata 11:22> oh yeah
<ampledata 11:22> that's better actually
<ampledata 11:23> https://github.com/opscode-cookbooks/python/blob/master/providers/virtualenv.rb#L28
<ampledata 11:27> i'll submit a thing thing
```

JIRA: http://tickets.opscode.com/browse/COOK-1415

PLEASEREVIEW: @jtimberman @coderanger @damm
