### PR TITLE
[COOK-1472] python_pip[virtualenv] fails in chef 10.12.0

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -124,8 +124,10 @@ def current_installed_version
       delimeter = /\s/
       version_check_cmd = "pip --version"
     end
-    p = shell_out!(version_check_cmd)
-    p.stdout.split(delimeter)[1].strip
+    p = shell_out(version_check_cmd)
+    unless p.stdout.split(delimeter).count < 2
+      p.stdout.split(delimeter)[1].strip
+    end
   rescue Chef::Exceptions::ShellCommandFailed, Mixlib::ShellOut::ShellCommandFailed
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-1472
