### PR TITLE
[COOK-1695] python_pip: Timeout value not passed to pip

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -142,16 +142,16 @@ end
 
 def install_package(name, version, timeout)
   v = "==#{version}" unless version.eql?('latest')
-  shell_out!("#{pip_cmd(@new_resource)} --default-timeout=#{timeout} install#{expand_options(@new_resource.options)} #{name}#{v}", :timeout => timeout)
+  shell_out!("#{pip_cmd(@new_resource)} --timeout=#{timeout} install#{expand_options(@new_resource.options)} #{name}#{v}", :timeout => timeout)
 end
 
 def upgrade_package(name, version, timeout)
   v = "==#{version}" unless version.eql?('latest')
-  shell_out!("#{pip_cmd(@new_resource)} --default-timeout=#{timeout} install --upgrade#{expand_options(@new_resource.options)} #{@new_resource.name}#{v}", :timeout => timeout)
+  shell_out!("#{pip_cmd(@new_resource)} --timeout=#{timeout} install --upgrade#{expand_options(@new_resource.options)} #{@new_resource.name}#{v}", :timeout => timeout)
 end
 
 def remove_package(name, version, timeout)
-  shell_out!("#{pip_cmd(@new_resource)} --default-timeout=#{timeout} uninstall -y#{expand_options(@new_resource.options)} #{@new_resource.name}", :timeout => timeout)
+  shell_out!("#{pip_cmd(@new_resource)} --timeout=#{timeout} uninstall -y#{expand_options(@new_resource.options)} #{@new_resource.name}", :timeout => timeout)
 end
 
 # TODO remove when provider is moved into Chef core


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1695

python_pip supports supplying a timeout value already. However, the timeout is only passed to shell_out. If a user supplies a timeout value that is greater than the default pip timeout, the user's timeout value is worthless.

Without this patch the pip command looks like:
`pip install [my options] package_name`

With this path the pip command looks like:
`pip --default-timeout=timeout_value install package_name`

It's important to point out that '--default-timeout' cannot be passed to the pip provider through the 'options' attribute paramater because it would generate the following pip command. Order matters.
`pip install --default-timeout=timeout install package_name`
