### PR TITLE
[COOK-1695] Upgrade pip resource with socket_timeout

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -150,9 +150,13 @@ def remove_package(version)
 end
 
 def pip_cmd(subcommand, version='')
-  options = { :timeout => new_resource.timeout, :user => new_resource.user, :group => new_resource.group }
-  options[:environment] = { 'HOME' => ::File.expand_path("~#{new_resource.user}") } if new_resource.user
-  shell_out!("#{which_pip(new_resource)} #{subcommand} #{new_resource.options} #{new_resource.package_name}#{version}", options)
+  shell_options = { :timeout => new_resource.timeout, :user => new_resource.user, :group => new_resource.group }
+  shell_options[:environment] = { 'HOME' => ::File.expand_path("~#{new_resource.user}") } if new_resource.user
+  shell_out!("#{which_pip(new_resource)} #{pip_options} #{subcommand} #{new_resource.options} #{new_resource.package_name}#{version}", shell_options)
+end
+
+def pip_options
+  "--timeout=#{@new_resource.socket_timeout}" if @new_resource.socket_timeout
 end
 
 # TODO remove when provider is moved into Chef core

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -28,8 +28,9 @@ def initialize(*args)
 end
 
 attribute :package_name, :kind_of => String, :name_attribute => true
-attribute :version, :default => nil
-attribute :timeout, :default => 900
+attribute :version, :kind_of => String, :default => nil
+attribute :timeout, :kind_of => Numeric, :default => 900
+attribute :socket_timeout, :kind_of => Numeric, :default => nil
 attribute :virtualenv, :kind_of => String
 attribute :user, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1695

Changes implemented
---------------------------
- add attribute `socket_timeout`; default to `nil` to indicate that we want to use the installed `pip`'s default timeout
- insert `--timeout=xxx` option to `pip` (not the subcommand) if `socket_timeout` is present

Related Ticket
-----------------
http://tickets.opscode.com/browse/COOK-1695

Related Pull Requests
--------------------------
* _#17 [COOK 1695] python_pip: Timeout value not passed to pip_
This request provides an alternate implementation for the issue as described in [its comments](http://tickets.opscode.com/browse/COOK-1695?focusedCommentId=28107&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28107).

* _#18 [COOK-1715] Add user and group to python_pip_
This request depends on #18 being merged as it requires the refactorings implemented therein.