### PR TITLE
[COOK 1063] teach python_pip about requirements files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ Install packages using the new hotness in Python package management...[`pip`](ht
 # Actions
 
 - :install: Install a pip package - if version is provided, install that specific version
+- :install_requirements: Install packages specified in a requirements file
 - :upgrade: Upgrade a pip package - if version is provided, upgrade to that specific version
 - :remove: Remove a pip package
 - :purge: Purge a pip package (this usually entails removing configuration files as well as the package itself).  With pip packages this behaves the same as `:remove`
 
 # Attribute Parameters
 
-- package_name: name attribute. The name of the pip package to install
+- package_name: name attribute. The name of the pip package to install or path to the requirements file
 - version: the version of the package to install/upgrade.  If no version is given latest is assumed.
 - virtualenv: virtualenv environment to install pip package into
 - options: Add additional options to the underlying pip package command
@@ -77,6 +78,11 @@ Install packages using the new hotness in Python package management...[`pip`](ht
     python_pip "django" do
       version "1.1.4"
       action :install
+    end
+
+    # install from requirements.txt
+    python_pip "/path/to/requirements.txt" do
+      action :install_requirements
     end
 
     # use this provider with the core package resource

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -44,6 +44,14 @@ action :install do
   end
 end
 
+action :install_requirements do
+    Chef::Log.info("Installing requirements from #{@new_resource.name}")
+    status = install_requirements()
+    if status
+      @new_resource.updated_by_last_action(true)
+    end
+end
+
 action :upgrade do
   if @current_resource.version != candidate_version
     orig_version = @current_resource.version || "uninstalled"
@@ -118,8 +126,13 @@ def candidate_version
   end
 end
 
-def install_package(version)
+def install_package(version='latest')
   pip_cmd('install', version == 'latest' ? '' : "==#{version}")
+end
+
+def install_requirements()
+  @new_resource.options "#{@new_resource.options} -r"
+  install_package()
 end
 
 def upgrade_package(version)

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-actions :install, :upgrade, :remove, :purge
+actions :install, :install_requirements, :upgrade, :remove, :purge
 
 attribute :package_name, :kind_of => String, :name_attribute => true
 attribute :version, :default => nil


### PR DESCRIPTION
## Changes implemented
- add **:install_requirements** action to pip resource
- get path to requirements file from name attribute
## Related Ticket

http://tickets.opscode.com/browse/COOK-1063
## Related Pull Requests
- _#18 [COOK-1715] Add user and group to python_pip_

This request depends on #18 being merged as it requires the refactorings implemented therein.
