### PR TITLE
[COOK-1866] /usr/bin/ is not pip_binary location when doing a source install on rhel.

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-if platform_family?("rhel")
+if platform_family?("rhel") and node['python']['install_method'] == 'package'
   pip_binary = "/usr/bin/pip"
 else
   pip_binary = "/usr/local/bin/pip"


### PR DESCRIPTION
Adding this check fixes the pip installation for rhel/centos source installs.
