### PR TITLE
[COOK-2449] Make the distribute download location an attribute 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,4 +39,4 @@ default['python']['checksum'] = '80e387bcf57eae8ce26726753584fd63e060ec11682d114
 default['python']['configure_options'] = %W{--prefix=#{python['prefix_dir']}}
 
 default['python']['distribute_script_url'] = 'http://python-distribute.org/distribute_setup.py'
-default['python']['distribute_option_download_base'] = 'https://pypi.python.org/packages/source/d/distribute/'
+default['python']['distribute_option']['download_base'] = 'https://pypi.python.org/packages/source/d/distribute/'

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -39,7 +39,7 @@ end
 execute "install-pip" do
   cwd Chef::Config[:file_cache_path]
   command <<-EOF
-  #{node['python']['binary']} distribute_setup.py --download-base=#{node['python']['distribute_option_download_base']}
+  #{node['python']['binary']} distribute_setup.py --download-base=#{node['python']['distribute_option']['download_base']}
   #{::File.dirname(pip_binary)}/easy_install pip
   EOF
   not_if { ::File.exists?(pip_binary) }


### PR DESCRIPTION
Add attributes to define the location of the distribute install script and the
package location. This allows independence of external sources that when down,
cause installation of distribute to fail.
