### PR TITLE
fix: `:user` and `:group` attribute placed wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Install packages using the new hotness in Python package management...[`pip`](ht
 - :install: Install a pip package - if version is provided, install that specific version (default)
 - :upgrade: Upgrade a pip package - if version is provided, upgrade to that specific version
 - :remove: Remove a pip package
-- :user: User to run pip as, for using with virtualenv
-- :group: Group to run pip as, for using with virtualenv
 - :purge: Purge a pip package (this usually entails removing configuration files as well as the package itself).  With pip packages this behaves the same as `:remove`
 
 # Attribute Parameters
@@ -61,6 +59,8 @@ Install packages using the new hotness in Python package management...[`pip`](ht
 - virtualenv: virtualenv environment to install pip package into
 - options: Add additional options to the underlying pip package command
 - timeout: timeout in seconds for the command to execute. Useful for pip packages that may take a long time to install. Default 900 seconds.
+- user: User to run pip as, for using with virtualenv
+- group: Group to run pip as, for using with virtualenv
 
 # Example
 


### PR DESCRIPTION
move some parameter descriptions from 'action' to 'attributes'
