### PR TITLE
[COOK-2917] Fix python::source fails without build tools.

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe "build-essential"
+
 configure_options = node['python']['configure_options'].join(" ")
 
 packages = value_for_platform_family(


### PR DESCRIPTION
python cookbook depends build-essential, but no include_recipes on source.py.
