### PR TITLE
[COOK-2882] User libdb-dev rather than libdb4.8-dev

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -22,7 +22,7 @@ configure_options = node['python']['configure_options'].join(" ")
 
 packages = value_for_platform_family(
              "rhel" => ["openssl-devel","bzip2-devel","zlib-devel","expat-devel","db4-devel","sqlite-devel","ncurses-devel","readline-devel"],
-             "default" => ["libssl-dev","libbz2-dev","zlib1g-dev","libexpat1-dev","libdb4.8-dev","libsqlite3-dev","libncursesw5-dev","libncurses5-dev","libreadline-dev"]
+             "default" => ["libssl-dev","libbz2-dev","zlib1g-dev","libexpat1-dev","libdb-dev","libsqlite3-dev","libncursesw5-dev","libncurses5-dev","libreadline-dev"]
            )
 
 packages.each do |dev_pkg|


### PR DESCRIPTION
libdb4.8-dev is not included in Ubuntu 12.10.  Using the virtual
package instead ensures we get whatever is available.
