### PR TITLE
[COOK-3125] No normal attributes

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -25,7 +25,7 @@ major_version = node['platform_version'].split('.').first.to_i
 if platform_family?('rhel') && major_version < 6
   include_recipe 'yum::epel'
   python_pkgs = ["python26", "python26-devel"]
-  node.set['python']['binary'] = "/usr/bin/python26"
+  node.default['python']['binary'] = "/usr/bin/python26"
 else
   python_pkgs = value_for_platform_family(
                   "debian" => ["python","python-dev"],


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3125

Python cookbook should set  a default attribute for python path
