### PR TITLE
[COOK-3240] Call apt recipe before installing python packages on debian systems

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,9 @@ license           "Apache 2.0"
 description       "Installs Python, pip and virtualenv. Includes LWRPs for managing Python packages with `pip` and `virtualenv` isolated Python environments."
 version           "1.3.5"
 
-depends           "build-essential"
-depends           "yum"
+%w{apt build-essential yum}.each do |cb|
+  depends cb
+end
 
 recipe "python", "Installs python, pip, and virtualenv"
 recipe "python::package", "Installs python using packages."

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -26,9 +26,11 @@ if platform_family?('rhel') && major_version < 6
   include_recipe 'yum::epel'
   python_pkgs = ["python26", "python26-devel"]
   node.set['python']['binary'] = "/usr/bin/python26"
+elsif platform_family?('debian')
+  include_recipe 'apt'
+  python_pkgs = ["python","python-dev"]
 else
   python_pkgs = value_for_platform_family(
-                  "debian" => ["python","python-dev"],
                   "rhel" => ["python","python-devel"],
                   "freebsd" => ["python"],
                   "smartos" => ["python27"],


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3240

I know the typical solution to this is to "just add the recipe to your role before X" but the python cookbook should be able to stand on its own.

Without `apt` called before this, and other, cookbooks, the output is:

``` ruby
[2013-06-25T18:37:47+00:00] INFO: Processing package[python] action install (python::package line 40)
[2013-06-25T18:37:47+00:00] INFO: Processing package[python-dev] action install (python::package line 40)

================================================================================
Error executing action `install` on resource 'package[python-dev]'
================================================================================

Chef::Exceptions::Exec
----------------------
apt-get -q -y install python-dev=2.7.3-0ubuntu2 returned 100, expected 0

Resource Declaration:
---------------------
# In /srv/chef/file_store/cookbooks/python/recipes/package.rb

 40:   package pkg do
 41:     action :install
 42:   end
 43: end

Compiled Resource:
------------------
# Declared in /srv/chef/file_store/cookbooks/python/recipes/package.rb:40:in `block in from_file'

package("python-dev") do
  action [:install]
  retries 0
  retry_delay 2
  package_name "python-dev"
  version "2.7.3-0ubuntu2"
  cookbook_name "python"
  recipe_name "package"
end

[2013-06-25T18:37:52+00:00] INFO: Running queued delayed notifications before re-raising exception
[2013-06-25T18:37:52+00:00] ERROR: Running exception handlers
[2013-06-25T18:37:53+00:00] FATAL: Saving node information to /srv/chef/file_store/failed-run-data.json
[2013-06-25T18:37:53+00:00] ERROR: Exception handlers complete
[2013-06-25T18:37:53+00:00] FATAL: Stacktrace dumped to /srv/chef/file_store/chef-stacktrace.out
[2013-06-25T18:37:53+00:00] FATAL: Chef::Exceptions::Exec: package[python-dev] (python::package line 40) had an error: Chef::Exceptions::Exec: apt-get -q -y install python-dev=2.7.3-0ubuntu2 returned 100, expected 0
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```

I'm surprised this hasn't been pull requested before (at least, not from what I've seen thus far).

This is an Ubuntu 12.04 VM by the way.
