### PR TITLE
[COOK-3350] Bootstrap pip using current setuptools instead of old distribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -38,5 +38,4 @@ default['python']['version'] = '2.7.5'
 default['python']['checksum'] = '3b477554864e616a041ee4d7cef9849751770bc7c39adaf78a94ea145c488059'
 default['python']['configure_options'] = %W{--prefix=#{python['prefix_dir']}}
 
-default['python']['distribute_script_url'] = 'http://python-distribute.org/distribute_setup.py'
-default['python']['distribute_option']['download_base'] = 'https://pypi.python.org/packages/source/d/distribute/'
+default['python']['setuptools_script_url'] = 'https://bitbucket.org/pypa/setuptools/downloads/ez_setup.py'

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -37,8 +37,8 @@ end
 # are broken...this feels like Rubygems!
 # http://stackoverflow.com/questions/4324558/whats-the-proper-way-to-install-pip-virtualenv-and-distribute-for-python
 # https://bitbucket.org/ianb/pip/issue/104/pip-uninstall-on-ubuntu-linux
-remote_file "#{Chef::Config[:file_cache_path]}/distribute_setup.py" do
-  source node['python']['distribute_script_url']
+remote_file "#{Chef::Config[:file_cache_path]}/setuptools_ez_setup.py" do
+  source node['python']['setuptools_script_url']
   mode "0644"
   not_if { ::File.exists?(pip_binary) }
 end
@@ -46,7 +46,7 @@ end
 execute "install-pip" do
   cwd Chef::Config[:file_cache_path]
   command <<-EOF
-  #{node['python']['binary']} distribute_setup.py --download-base=#{node['python']['distribute_option']['download_base']}
+  #{node['python']['binary']} setuptools_ez_setup.py
   #{::File.dirname(pip_binary)}/easy_install pip
   EOF
   not_if { ::File.exists?(pip_binary) }


### PR DESCRIPTION
Avoids broken setuptools when updating pip packages which depend on distribute
See http://tickets.opscode.com/browse/COOK-3350 and https://github.com/pypa/pip/issues/1033
