### PR TITLE
[COOK-3788] Make symlink for source built python

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -56,3 +56,12 @@ bash "build-and-install-python" do
   }) if platform?("ubuntu") && node['platform_version'].to_f >= 12.04
   not_if { ::File.exists?(install_path) }
 end
+
+# Link install as the default python, to support Python 3.x
+# Otherwise the pip and virtualenv recipes won't work properly
+link node['python']['binary'] do
+  to install_path
+  not_if { ::File.exists?(node['python']['binary']) }
+end
+
+


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3788

Creates symlink of source built python as python. This allows Python 3.3 to be the default Python.
