### PR TITLE
allow users to override the python package name to install

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+default['python']['binary_name']          = 'python'
 default['python']['install_method'] = 'package'
 major_version = platform_version.split('.').first.to_i
 if python['install_method'] == 'package'
@@ -27,6 +28,7 @@ if python['install_method'] == 'package'
       default['python']['python_pkgs']        = ["python","python-dev"]
     when "rhel"
       if major_version < 6
+        default['python']['binary_name']          = 'python26'
         default['python']['python_pkgs']      = ["python26", "python26-devel"]
       else
         default['python']['python_pkgs']      = ["python","python-devel"]
@@ -43,8 +45,6 @@ if python['install_method'] == 'package'
 else
   default['python']['prefix_dir']         = '/usr/local'
 end
-default['python']['binary_name']          = 'python'
-default['python']['binary'] = "#{node['python']['prefix_dir']}/bin/#{node['python']['binary_name']}"
 
 default['python']['url'] = 'http://www.python.org/ftp/python'
 default['python']['version'] = '2.7.5'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -24,7 +24,6 @@ major_version = node['platform_version'].split('.').first.to_i
 # repo & package
 if platform_family?('rhel') && major_version < 6
   include_recipe 'yum::epel'
-  node.default['python']['binary'] = "/usr/bin/python26"
 end
 
 node['python']['python_pkgs'].each do |pkg|

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -32,11 +32,12 @@ elsif platform_family?("smartos")
 else
   pip_binary = "/usr/local/bin/pip"
 end
+python_binary = "#{node['python']['prefix_dir']}/bin/#{node['python']['binary_name']}"
 
 cookbook_file "#{Chef::Config[:file_cache_path]}/ez_setup.py" do
   source 'ez_setup.py'
   mode "0644"
-  not_if "#{node['python']['binary']} -c 'import setuptools'"
+  not_if "#{python_binary} -c 'import setuptools'"
 end
 
 cookbook_file "#{Chef::Config[:file_cache_path]}/get-pip.py" do
@@ -48,15 +49,15 @@ end
 execute "install-setuptools" do
   cwd Chef::Config[:file_cache_path]
   command <<-EOF
-  #{node['python']['binary']} ez_setup.py
+  #{python_binary} ez_setup.py
   EOF
-  not_if "#{node['python']['binary']} -c 'import setuptools'"
+  not_if "#{python_binary} -c 'import setuptools'"
 end
 
 execute "install-pip" do
   cwd Chef::Config[:file_cache_path]
   command <<-EOF
-  #{node['python']['binary']} get-pip.py
+  #{python_binary} get-pip.py
   EOF
   not_if { ::File.exists?(pip_binary) }
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -60,9 +60,10 @@ end
 
 # Link install as the default python, to support Python 3.x
 # Otherwise the pip and virtualenv recipes won't work properly
-link node['python']['binary'] do
+python_binary = "#{node['python']['prefix_dir']}/bin/#{node['python']['binary_name']}"
+link python_binary do
   to install_path
-  not_if { ::File.exists?(node['python']['binary']) }
+  not_if { ::File.exists?(python_binary) }
 end
 
 


### PR DESCRIPTION
allow users to override the python package names. This is important with AWS Opsworks, the package `python` installs python 2.6, if you want to install python 2.7 you have to use the package named `python27`

All you have to do now to override the installed package is set the attribute to the package names you want

default['python']['python_pkgs']      = ["python27", "python27-devel"]
