### PR TITLE
use .tgz archive

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -35,8 +35,8 @@ end
 version = node['python']['version']
 install_path = "#{node['python']['prefix_dir']}/bin/python#{version.split(/(^\d+\.\d+)/)[1]}"
 
-remote_file "#{Chef::Config[:file_cache_path]}/Python-#{version}.tar.bz2" do
-  source "#{node['python']['url']}/#{version}/Python-#{version}.tar.bz2"
+remote_file "#{Chef::Config[:file_cache_path]}/Python-#{version}.tgz" do
+  source "#{node['python']['url']}/#{version}/Python-#{version}.tgz"
   checksum node['python']['checksum']
   mode "0644"
   not_if { ::File.exists?(install_path) }
@@ -45,7 +45,7 @@ end
 bash "build-and-install-python" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOF
-  tar -jxvf Python-#{version}.tar.bz2
+  tar -zxvf Python-#{version}.tgz
   (cd Python-#{version} && ./configure #{configure_options})
   (cd Python-#{version} && make && make #{make_options})
   EOF


### PR DESCRIPTION
Python project offers .tgz archive officially instead of .tar.bz2. In particular, Python-2.7.6.tar.bz2 doesn't exists currently, so I can't build 2.7.6

http://www.python.org/ftp/python/2.7.6/
