### PR TITLE
[COOK-3871] Add attribute for setuptools base URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,7 @@ default['python']['configure_options'] = %W{--prefix=#{python['prefix_dir']}}
 default['python']['make_options'] = %W{install}
 
 default['python']['setuptools_script_url'] = 'https://bitbucket.org/pypa/setuptools/raw/0.8/ez_setup.py'
+default['python']['setuptools_base_url'] = 'https://pypi.python.org/packages/source/s/setuptools/'
 default['python']['pip_script_url'] = 'https://raw.github.com/pypa/pip/master/contrib/get-pip.py'
 default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -48,7 +48,7 @@ end
 execute "install-setuptools" do
   cwd Chef::Config[:file_cache_path]
   command <<-EOF
-  #{node['python']['binary']} ez_setup.py
+  #{node['python']['binary']} ez_setup.py --download-base=#{node['python']['setuptools_base_url']}
   EOF
   not_if "#{node['python']['binary']} -c 'import setuptools'"
 end


### PR DESCRIPTION
To make it possible to install setuptools from a non-Internet site we
pass the base URL as an argument to ez_setup.py.

Signed-off-by: Peter Jönsson peter.jonsson@klarna.com
