### PR TITLE
added version checking to virtualenv install not_if statement

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -36,7 +36,9 @@ end
 cookbook_file "#{Chef::Config[:file_cache_path]}/ez_setup.py" do
   source 'ez_setup.py'
   mode "0644"
-  not_if "#{node['python']['binary']} -c 'import setuptools'"
+  not_if "#{node['python']['binary']} -c 'import pkg_resources, sys;\
+  sys.exit(1) if float(pkg_resources.get_distribution(\"setuptools\")\
+  .version[:3]) < 0.8 else sys.exit(0)'"
 end
 
 cookbook_file "#{Chef::Config[:file_cache_path]}/get-pip.py" do
@@ -50,7 +52,9 @@ execute "install-setuptools" do
   command <<-EOF
   #{node['python']['binary']} ez_setup.py
   EOF
-  not_if "#{node['python']['binary']} -c 'import setuptools'"
+  not_if "#{node['python']['binary']} -c 'import pkg_resources, sys;\
+  sys.exit(1) if float(pkg_resources.get_distribution(\"setuptools\")\
+  .version[:3]) < 0.8 else sys.exit(0)'"
 end
 
 execute "install-pip" do


### PR DESCRIPTION
When installing virtualenv pip errors, because pip's wheel archives are not supported in that version, and requires setuptools version 0.8 errors.

This cookbook packages setuptools 0.8, however, it only checks if setup tools is installed, if we are asserting to install it, lets make sure we check the version. 

Therefore, I have amended the 'check' (by committing some python styling crimes), which checks the version is not less than 0.8, if it is it installs it, otherwise it doesent.
