### PR TITLE
[COOK-4244] Fix the pip version_check_cmd to use the virtualenv pip when applicable

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -112,7 +112,7 @@ def current_installed_version
     # incase you upgrade pip with pip!
     if new_resource.package_name.eql?('pip')
       delimeter = /\s/
-      version_check_cmd = "pip --version"
+      version_check_cmd = "#{which_pip(@new_resource)} --version"
     end
     result = shell_out(version_check_cmd)
     (result.exitstatus == 0) ? result.stdout.split(delimeter)[1].strip : nil


### PR DESCRIPTION
Otherwise when upgrading the pip in your virtualenv, it will incorrectly get the system pip version and may skip the upgrade.
