### PR TITLE
Add an optional cache folder for pip to use when installing libs.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,12 +45,17 @@ suites:
   - recipe[minitest-handler]
   - recipe[python]
   - recipe[python_test::cook-3084]
-  attributes: {python: {install_method: "source"}}
+  attributes:
+    python:
+      install_method: "source"
+      pip_cache_location: "/var/pip/cache"
+
 - name: exert
   excludes: ["centos-5.9"]
   run_list:
   - recipe[python]
   - recipe[python_test::test_exert]
+
 - name: virtualenv
   run_list:
   - recipe[python]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,7 @@ default['python']['configure_options'] = %W{--prefix=#{python['prefix_dir']}}
 default['python']['make_options'] = %W{install}
 
 default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
+default['python']['pip_cache_location'] = nil
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -149,13 +149,22 @@ def remove_package(version)
   pip_cmd('uninstall')
 end
 
+def expand_options(subcommand, opts)
+  if subcommand == 'install'
+    unless node['python']['pip_cache_location'].nil? && opts.include?('--download-cache')
+      opts << " --download-cache=\"#{node['python']['pip_cache_location']}\""
+    end
+  end
+  opts
+end
+
 def pip_cmd(subcommand, version='')
   options = { :timeout => new_resource.timeout, :user => new_resource.user, :group => new_resource.group }
   environment = Hash.new
   environment['HOME'] = Dir.home(new_resource.user) if new_resource.user
   environment.merge!(new_resource.environment) if new_resource.environment && !new_resource.environment.empty?
   options[:environment] = environment
-  shell_out!("#{which_pip(new_resource)} #{subcommand} #{new_resource.options} #{new_resource.package_name}#{version}", options)
+  shell_out!("#{which_pip(new_resource)} #{subcommand} #{expand_options(subcommand, new_resource.options)} #{new_resource.name}#{version}", options)
 end
 
 # TODO remove when provider is moved into Chef core

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -51,3 +51,10 @@ python_pip 'setuptools' do
   action :upgrade
   version node['python']['setuptools_version']
 end
+
+if node['python']['pip_cache_location']
+  directory node['python']['pip_cache_location'] do
+    recursive true
+    action :create
+  end
+end


### PR DESCRIPTION
I often find it useful to specify a cache folder for pip. Perhaps being able to configure it as a node level attribute will make people's lives a little easier.
