### PR TITLE
Adding installation of python 2.7 on Amazon.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs Python, pip and virtualenv. Includes LWRPs for managing Python packages with `pip` and `virtualenv` isolated Python environments."
-version           "1.4.7"
+version           "1.4.8"
 
 depends           "build-essential"
 depends           "yum-epel"

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -37,6 +37,10 @@ else
                 )
 end
 
+if platform?('amazon')
+  python_pkgs = ['python27', 'python27-devel']
+end
+
 python_pkgs.each do |pkg|
   package pkg do
     action :install


### PR DESCRIPTION
Amazon requires installing using package name python27 rather than python.

Since the platform family is still detected as 'rhel', it needs a separate check against the platform.
