### PR TITLE
[COOK-4250] Python package recipe should allow package names to be configured

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 #
 
 default['python']['install_method'] = 'package'
+default['python']['package_names'] = nil  # see package recipe for platform-specific defaults
 
 if python['install_method'] == 'package'
   case platform

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -20,9 +20,11 @@
 
 major_version = node['platform_version'].split('.').first.to_i
 
+if node['python']['package_names']
+  python_pkgs = node['python']['package_names']
 # COOK-1016 Handle RHEL/CentOS namings of python packages, by installing EPEL
 # repo & package
-if platform_family?('rhel') && major_version < 6
+elsif platform_family?('rhel') && major_version < 6
   include_recipe 'yum-epel'
   python_pkgs = ["python26", "python26-devel"]
   node.default['python']['binary'] = "/usr/bin/python26"


### PR DESCRIPTION
Allow OS package names (generally determined by platform family) to be overrided by an attribute

[[COOK-4250] Python package recipe should allow package names to be configured](https://tickets.opscode.com/browse/COOK-4250)