### PR TITLE
Fix issue with underscores in package names. Fixes #91

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,6 +39,11 @@ suites:
   - recipe[python]
   - recipe[python_test::cook-3084]
   attributes: {}
+- name: pip
+  run_list:
+  - recipe[minitest-handler]
+  - recipe[python]
+  - recipe[python_test::test_pip]
 
 - name: source
   run_list:

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -108,7 +108,8 @@ def current_installed_version
   @current_installed_version ||= begin
     delimeter = /==/
 
-    version_check_cmd = "#{which_pip(new_resource)} freeze | grep -i '^#{new_resource.package_name}=='"
+    normalized_package_name = new_resource.package_name.gsub('_', '-')
+    version_check_cmd = "#{which_pip(new_resource)} freeze | grep -i '^#{normalized_package_name}=='"
     # incase you upgrade pip with pip!
     if new_resource.package_name.eql?('pip')
       delimeter = /\s/

--- a/test/cookbooks/python_test/files/default/tests/minitest/test_pip_test.rb
+++ b/test/cookbooks/python_test/files/default/tests/minitest/test_pip_test.rb
@@ -1,0 +1,15 @@
+require 'minitest/spec'
+
+describe_recipe 'python_test::test_pip' do
+  include MiniTest::Chef::Assertions
+  include MiniTest::Chef::Context
+  include MiniTest::Chef::Resources
+
+  it "ran first should_dsl pip install" do
+    assert File.exist?("/tmp/first-install.txt"), `/tmp/virtualenv/bin/pip freeze`
+  end
+
+  it "did not run second should_dsl pip install" do
+    assert !File.exist?("/tmp/second-install.txt"), `/tmp/virtualenv/bin/pip freeze`
+  end
+end

--- a/test/cookbooks/python_test/recipes/test_pip.rb
+++ b/test/cookbooks/python_test/recipes/test_pip.rb
@@ -1,0 +1,51 @@
+#
+# Author:: Hugo Lopes Tavares <hltbra@gmail.com>
+# Cookbook Name:: python
+# Recipe:: test_virtualenv
+#
+# Copyright 2013, Heavy Water Operations, LLC.
+# Copyright 2014, Yipit, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+file "/tmp/first-install.txt" do
+  content "test"
+  action :nothing
+end
+
+file "/tmp/second-install.txt" do
+  content "test"
+  action :nothing
+end
+
+python_virtualenv "/tmp/virtualenv" do
+  owner "root"
+  group "root"
+  action :create
+end
+
+python_pip "should_dsl first install" do
+  package_name "should_dsl"
+  virtualenv "/tmp/virtualenv"
+  version "2.1.2"
+  notifies :create, "file[/tmp/first-install.txt]"
+end
+
+python_pip "should_dsl second install" do
+  package_name "should_dsl"
+  virtualenv "/tmp/virtualenv"
+  # same version as before
+  version "2.1.2"
+  notifies :create, "file[/tmp/second-install.txt]"
+end


### PR DESCRIPTION
Before this commit, `python_pip` reinstalled packages that contain underscores in their names.
More details at https://github.com/poise/python/issues/91

PS.: I ran into some issues with the tests and VM memory size. In my local development I increased memory size to 1030MB and it worked fine. The error I got was `FATAL: Chef::Exceptions::ChildConvergeError: Chef run process terminated by signal 9 (KILL)`, that I did some research and it is related to not enough memory. I still don't know why that happened.
