### PR TITLE
Add specs for for package, pip and source recipes; minor fix to default spec

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -5,10 +5,6 @@ describe 'python::default' do
     ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04').converge described_recipe
   end
 
-  before do
-    stub_command("/usr/bin/python -c 'import setuptools'").and_return(true)
-  end
-
   it 'includes python::package by default' do
     expect(chef_run).to include_recipe('python::package')
   end

--- a/spec/package_spec.rb
+++ b/spec/package_spec.rb
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+require 'spec_helper'
+
+describe 'python::package' do
+  describe 'on an unknown platform' do
+    it 'sets the python packages to python and python-dev' do
+      chef_run = ChefSpec::Runner.new.converge(described_recipe)
+      expect(chef_run).to install_package('python')
+      expect(chef_run).to install_package('python-dev')
+    end
+  end
+
+  describe 'on Debian-family platforms' do
+    it 'sets the python packages to python and python-dev' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'ubuntu', version: '12.04').converge(
+        described_recipe)
+      expect(chef_run).to install_package('python')
+      expect(chef_run).to install_package('python-dev')
+    end
+  end
+
+  describe 'on Fedora-family platforms' do
+    it 'sets the python packages to python and python-devel' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'fedora', version: '18').converge(
+        described_recipe)
+      expect(chef_run).to install_package('python')
+      expect(chef_run).to install_package('python-devel')
+    end
+  end
+
+  describe 'on FreeBSD-family platforms' do
+    it 'sets the python packages to python' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'freebsd', version: '9.1').converge(
+        described_recipe)
+      expect(chef_run).to install_package('python')
+    end
+  end
+
+  describe 'on Red Hat-family platforms with version < 6' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(platform: 'redhat', version: '5.10').converge(
+        described_recipe)
+    end
+
+    it 'sets the python packages to python26 and python26-devel' do
+      expect(chef_run).to install_package('python26')
+      expect(chef_run).to install_package('python26-devel')
+    end
+
+    it 'includes the yum-epel recipe' do
+      expect(chef_run).to include_recipe('yum-epel')
+    end
+  end
+
+  describe 'on Red Hat-family platforms with version > 6' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(platform: 'redhat', version: '6.0').converge(
+        described_recipe)
+    end
+
+    it 'sets the python packages to python and python-devel' do
+      expect(chef_run).to install_package('python')
+      expect(chef_run).to install_package('python-devel')
+    end
+
+    it 'does not inlcude the yum-epel recipe' do
+      expect(chef_run).not_to include_recipe('yum-epel')
+    end
+  end
+
+  describe 'on SmartOS-family platforms' do
+    it 'sets the python packages to python27' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'smartos', version: 'joyent_20130111T180733Z').converge(
+        described_recipe)
+      expect(chef_run).to install_package('python27')
+    end
+  end
+end

--- a/spec/pip_spec.rb
+++ b/spec/pip_spec.rb
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+require 'spec_helper'
+
+describe 'python::pip' do
+  before do
+    # Chef won't run without a stubbed default "true" value for ::File.exists?:
+    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exists?).with('/usr/bin/pip').and_return(false)
+    ::File.stub(:exists?).with('/usr/local/bin/pip').and_return(false)
+    ::File.stub(:exists?).with('/opt/local/bin/pip').and_return(false)
+  end
+
+  describe 'on a source install' do
+    it 'uses /usr/local/bin/python to install pip on a source install' do
+      chef_run = ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04')
+      chef_run.node.set['python']['install_method'] = 'source'
+      chef_run.converge(described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/local/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on an unknown platform package install' do
+    it 'uses /usr/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new.converge(described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on Debian-family platforms' do
+    it 'uses /usr/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'ubuntu', version: '12.04').converge(
+        described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on Fedora-family platforms' do
+    it 'uses /usr/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'fedora', version: '18').converge(
+        described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on FreeBSD-family platforms' do
+    it 'uses /usr/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'freebsd', version: '9.1').converge(
+        described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on Red Hat-family platforms with version < 6' do
+    it 'uses the python26 binary to install pip' do
+      # Need to converge python::package via python::default to properly set
+      # node['python']['binary']!
+      chef_run = ChefSpec::Runner.new(
+        platform: 'redhat', version: '5.10').converge(
+        'python::default')
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python26 get-pip.py\n")
+    end
+  end
+
+  describe 'on Red Hat-family platforms with version > 6' do
+    it 'uses /usr/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'redhat', version: '6.0').converge(
+        described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /usr/bin/python get-pip.py\n")
+    end
+  end
+
+  describe 'on SmartOS-family platforms' do
+    it 'uses /opt/local/bin/python to install pip' do
+      chef_run = ChefSpec::Runner.new(
+        platform: 'smartos', version: 'joyent_20130111T180733Z').converge(
+        described_recipe)
+      expect(chef_run).to run_execute('install-pip').with(
+        command: "  /opt/local/bin/python get-pip.py\n")
+    end
+  end
+end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+require 'spec_helper'
+
+describe 'python::source' do
+
+  before do
+    # Chef won't run without a stubbed default "true" value for ::File.exists?:
+    ::File.stub(:exists?).and_return(true)
+    ::File.stub(:exists?).with('/usr/local/bin/python').and_return(false)
+    ::File.stub(:exists?).with('/usr/local/bin/python2.7').and_return(false)
+  end
+
+  describe 'on a non-Red Hat plaform' do
+    it 'installs the default package set' do
+      chef_run = ChefSpec::Runner.new(platform: 'ubuntu', version: '12.04')
+      chef_run.node.set['python']['install_method'] = 'source'
+      chef_run.converge(described_recipe)
+      %w{ libssl-dev libbz2-dev zlib1g-dev libexpat1-dev libdb-dev
+          libsqlite3-dev libncursesw5-dev libncurses5-dev libreadline-dev
+          libsasl2-dev libgdbm-dev }.each do |pkg|
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+  end
+
+  describe 'on Red Hat-family platforms' do
+    it 'installs the rhel-specific package set' do
+      chef_run = ChefSpec::Runner.new(platform: 'redhat', version: '6.0')
+      chef_run.node.set['python']['install_method'] = 'source'
+      chef_run.converge(described_recipe)
+      %w{ openssl-devel bzip2-devel zlib-devel expat-devel db4-devel
+          sqlite-devel ncurses-devel readline-devel }.each do |pkg|
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+  end
+end


### PR DESCRIPTION
ChefSpec tests for the package, pip and source recipes; remove stub from default spec not needed since 213c37e5.

I wrote my own version of specifying the python package files via an attribute... then I saw there were already two pull requests to do that.  These are the specs I wrote for my implementation; hopefully they'll be useful when adding #58 and/or #90.

Thanks for considering this pull request.