### PR TITLE
Fix version detection (setuptools and distribute)

### DIFF
--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -106,17 +106,13 @@ end
 
 def current_installed_version
   @current_installed_version ||= begin
-    delimeter = /==/
-
-    normalized_package_name = new_resource.package_name.gsub('_', '-')
-    version_check_cmd = "#{which_pip(new_resource)} freeze | grep -i '^#{normalized_package_name}=='"
-    # incase you upgrade pip with pip!
-    if new_resource.package_name.eql?('pip')
-      delimeter = /\s/
-      version_check_cmd = "#{which_pip(@new_resource)} --version"
+    out = nil
+    package_name = new_resource.package_name.gsub('_', '-')
+    pattern = Regexp.new("^#{Regexp.escape(package_name)} \\(([^)]+)\\)$", true)
+    shell_out("#{which_pip(new_resource)} list").stdout.lines.find do |line|
+      out = pattern.match(line)
     end
-    result = shell_out(version_check_cmd)
-    (result.exitstatus == 0) ? result.stdout.split(delimeter)[1].strip : nil
+    out.nil? ? nil : out[1]
   end
 end
 


### PR DESCRIPTION
Fixes #81

The versions of `distribute`, `pip`, `setuptools` and `wsgiref` are excluded from the output of `pip freeze`, however they do show up in the output from `pip list`. This allows us to use a more general implentation of parsing the output from `pip list` to get the current version of all distributions.

Also removes a dependency on `grep`.

Distributions excluded from `pip freeze`:
https://github.com/pypa/pip/blob/2ad8888901c041b8f9aacebb3a16d55bf631e867/pip/util.py#L372
