### PR TITLE
Adding environment override attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 python Cookbook CHANGELOG
 =========================
 This file is used to list changes made in each version of the python cookbook.
+v1.4.8
+------
+- ** Adding python environment attribute to allow overriding of the default python/pip environment (useful when http(s)_proxying is required)
 
 v1.4.6
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ python Cookbook CHANGELOG
 This file is used to list changes made in each version of the python cookbook.
 v1.4.8
 ------
-- ** Adding python environment attribute to allow overriding of the default python/pip environment (useful when http(s)_proxying is required)
+- Adding python environment attribute to allow overriding of the default python/pip environment (useful when http(s)_proxying is required).
 
 v1.4.6
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ python Cookbook CHANGELOG
 This file is used to list changes made in each version of the python cookbook.
 v1.4.8
 ------
+### Improvement
 - Adding python environment attribute to allow overriding of the default python/pip environment (useful when http(s)_proxying is required).
 
 v1.4.6

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Attributes
 See `attributes/default.rb` for default values.
 
 - `node["python"]["install_method"]` - method to install python with, default `package`.
+- `node["python"]["environment"]` - specify a default environment for pip/python commands executed via this cookbook
 
 The file also contains the following attributes:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Attributes
 See `attributes/default.rb` for default values.
 
 - `node["python"]["install_method"]` - method to install python with, default `package`.
-- `node["python"]["environment"]` - specify a default environment for pip/python commands executed via this cookbook
+- `node["python"]["environment"]` - specify a default environment (i.e. {'http_proxy' => "http://..."}) for pip/python commands executed via this cookbook, default `{}`
 
 The file also contains the following attributes:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,3 +43,4 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil
+default['python']['environment'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,4 +43,4 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil
-default['python']['environment'] = nil
+default['python']['environment'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs Python, pip and virtualenv. Includes LWRPs for managing Python packages with `pip` and `virtualenv` isolated Python environments."
-version           "1.4.7"
+version           "1.4.8"
 
 depends           "build-essential"
 depends           "yum-epel"

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -44,12 +44,12 @@ execute "install-pip" do
   command <<-EOF
   #{node['python']['binary']} get-pip.py
   EOF
-  environment "#{['python']['environment']}"
+  environment (node['python']['environment'])
   not_if { ::File.exists?(pip_binary) }
 end
 
 python_pip 'setuptools' do
   action :upgrade
-  environment "#{['python']['environment']}"
+  environment (node['python']['environment'])
   version node['python']['setuptools_version']
 end

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -44,10 +44,12 @@ execute "install-pip" do
   command <<-EOF
   #{node['python']['binary']} get-pip.py
   EOF
+  environment "#{['python']['environment']}"
   not_if { ::File.exists?(pip_binary) }
 end
 
 python_pip 'setuptools' do
   action :upgrade
+  environment "#{['python']['environment']}"
   version node['python']['setuptools_version']
 end

--- a/recipes/virtualenv.rb
+++ b/recipes/virtualenv.rb
@@ -22,5 +22,6 @@ include_recipe "python::pip"
 
 python_pip "virtualenv" do
   action :upgrade
+  environment "#{['python']['environment']}"
   version node['python']['virtualenv_version']
 end

--- a/recipes/virtualenv.rb
+++ b/recipes/virtualenv.rb
@@ -22,6 +22,6 @@ include_recipe "python::pip"
 
 python_pip "virtualenv" do
   action :upgrade
-  environment "#{['python']['environment']}"
+  environment (node['python']['environment'])
   version node['python']['virtualenv_version']
 end

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -34,4 +34,4 @@ attribute :virtualenv, :kind_of => String
 attribute :user, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
 attribute :options, :kind_of => String, :default => ''
-attribute :environment, :kind_of => Hash, :default => Chef::Config['python']['environment']
+attribute :environment, :kind_of => Hash, :default => node['python']['environment']

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -34,4 +34,4 @@ attribute :virtualenv, :kind_of => String
 attribute :user, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
 attribute :options, :kind_of => String, :default => ''
-attribute :environment, :kind_of => Hash, :default => {}
+attribute :environment, :kind_of => Hash, :default => {"#{['python']['environment']}"}

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -34,4 +34,4 @@ attribute :virtualenv, :kind_of => String
 attribute :user, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
 attribute :options, :kind_of => String, :default => ''
-attribute :environment, :kind_of => Hash, :default => {"#{['python']['environment']}"}
+attribute :environment, :kind_of => Hash, :default => {node['python']['environment']}

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -34,4 +34,4 @@ attribute :virtualenv, :kind_of => String
 attribute :user, :regex => Chef::Config[:user_valid_regex]
 attribute :group, :regex => Chef::Config[:group_valid_regex]
 attribute :options, :kind_of => String, :default => ''
-attribute :environment, :kind_of => Hash, :default => {node['python']['environment']}
+attribute :environment, :kind_of => Hash, :default => Chef::Config['python']['environment']


### PR DESCRIPTION
Added some code to allow cookbook users override the default python/pip environment.
Was required to allow specifying http_proxy/https_proxy environment variables when using the pip/virtualenv install recipes and also to allow these environment variable to persist when using the python_pip LWRP

Example usage:
node.set['python']['environment'] = { :http_proxy => "http://...", :https_proxy => "https://..."}
include_recipe 'python'