### PR TITLE
Fix for issue #100

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -28,7 +28,7 @@ if platform_family?('rhel') && major_version < 6
   node.default['python']['binary'] = "/usr/bin/python26"
 else
   python_pkgs = value_for_platform_family(
-                  "debian"  => ["python","python-dev"],
+                  "debian"  => ["python","python-dev","python-setuptools"],
                   "rhel"    => ["python","python-devel"],
                   "fedora"  => ["python","python-devel"],
                   "freebsd" => ["python"],


### PR DESCRIPTION
I also had issue #100 on Ubuntu 12.04 and 14.04 systems when I upgraded to the latest version of the Python cookbook. 

I tracked it down to `get-pip.py` refusing to install pip on my systems unless the python-setuptools package was installed first. If you get that fixed, then later on in the package it will upgrade setuptools for you.

I have this fix running successfully on my systems now.
