### PR TITLE
[COOK-2809] Added Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ Requirements
 ### Platforms
 - Debian, Ubuntu
 - CentOS, Red Hat, Fedora
+- Windows
 
 ### Cookbooks
 - build-essential
 - yum
+- windows
 
 NOTE: The `yum` cookbook is a dependency of the cookbook, and will be used to install [EPEL](http://fedoraproject.org/wiki/EPEL) on RedHet/CentOS 5.x systems to provide the Python 2.6 packages.
 
@@ -23,7 +25,7 @@ Attributes
 ----------
 See `attributes/default.rb` for default values.
 
-- `node["python"]["install_method"]` - method to install python with, default `package`.
+- `node["python"]["install_method"]` - method to install python with, default `package`. On Windows this defaults to 'windows'.
 
 The file also contains the following attributes:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,3 +43,14 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil
+
+if platform?('windows')
+  default['python']['install_method'] = 'windows'
+  default['python']['install_64bit'] = node['kernel']['machine'] =~ /x86_64/
+  default['python']['msi_checksum_64bit'] = 'cec70fb80feb742b29a5daf6dfd3559c3bc18539baccdeba78ad0b80802d1059'
+  default['python']['msi_checksum_32bit'] = 'ccc5e024e79f5783118a5286a9a5dbb211c194aecb66fbf47e01295394de093b'
+  default['python']['install_dir'] = 'C:\Python27'
+  default['python']['binary'] = "#{node['python']['install_dir']}/python.exe"
+  default['python']['pip_location'] = "#{node['python']['install_dir']}/Scripts/pip.exe"
+  default['python']['virtualenv_location'] = "#{node['python']['install_dir']}/Scripts/virtualenv.exe"
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,13 +7,15 @@ version           "1.4.7"
 
 depends           "build-essential"
 depends           "yum-epel"
+depends           "windows"
 
 recipe "python", "Installs python, pip, and virtualenv"
 recipe "python::package", "Installs python using packages."
 recipe "python::source", "Installs python from source."
 recipe "python::pip", "Installs pip from source."
 recipe "python::virtualenv", "Installs virtualenv using the python_pip resource."
+recipe "python::windows", "Installs python on Windows from an MSI package"
 
-%w{ debian ubuntu centos redhat fedora freebsd smartos }.each do |os|
+%w{ debian ubuntu centos redhat fedora freebsd smartos windows }.each do |os|
   supports os
 end

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -25,6 +25,8 @@
 
 if node['python']['install_method'] == 'source'
   pip_binary = "#{node['python']['prefix_dir']}/bin/pip"
+elsif platform?('windows')
+  pip_binary = node['python']['pip_location']
 elsif platform_family?("rhel", "fedora")
   pip_binary = "/usr/bin/pip"
 elsif platform_family?("smartos")

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -1,0 +1,40 @@
+#
+# Author:: Shawn Neal <sneal@daptiv.com>
+# Cookbook Name:: python
+# Recipe:: windows
+#
+# Copyright 2014, Daptiv Solutions LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version = node['python']['version']
+
+if node['python']['install_64bit']
+  msi_filename = "python-#{version}.amd64.msi"
+  msi_checksum = node['python']['msi_checksum_64bit']
+else
+  msi_filename = "python-#{version}.msi"
+  msi_checksum = node['python']['msi_checksum_32bit']
+end
+
+msi_options = 'ALLUSERS=1' #Workaround for http://bugs.python.org/issue16188
+msi_options << " TARGETDIR=#{win_friendly_path(node['python']['install_dir'])}"
+
+windows_package "Python #{version}" do
+  action :install
+  source "#{node['python']['url']}/#{version}/#{msi_filename}"
+  checksum msi_checksum
+  options msi_options
+  installer_type :msi
+end


### PR DESCRIPTION
Added Windows specific installation recipe along with pip and virtualenv support. Recipe supports both 32bit and 64bit installations on Windows using MSI.
