### PR TITLE
Upgrade setuptools twice, since it won't upgrade once

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -47,7 +47,9 @@ execute "install-pip" do
   not_if { ::File.exists?(pip_binary) }
 end
 
-python_pip 'setuptools' do
-  action :upgrade
-  version node['python']['setuptools_version']
+(0..1).each do |i|
+  python_pip 'setuptools' do
+    action :upgrade
+    version node['python']['setuptools_version']
+  end
 end


### PR DESCRIPTION
This has been already reported for CentOS 5.x in https://github.com/poise/python/issues/111 and reported for CentOS 6.5 in https://github.com/poise/python/issues/100. A quick Google search confirms that some users of Stackoverflow have also sought help with the broken behavior: http://stackoverflow.com/a/25288078/70665

The actual error, on a fresh install of CentOS 6.5 and then applying this cookbook, is:

```
       Recipe: python::virtualenv
         * python_pip[virtualenv] action upgrade[2014-08-22T12:30:43+00:00] INFO: Processing python_pip[virtualenv] action upgrade (python::virtualenv line 23)
       [2014-08-22T12:30:43+00:00] INFO: Upgrading python_pip[virtualenv] version from uninstalled to latest
       
           
           ================================================================================
           Error executing action `upgrade` on resource 'python_pip[virtualenv]'
           ================================================================================
           
           Mixlib::ShellOut::ShellCommandFailed
           ------------------------------------
           Expected process to exit with [0], but received '1'
           ---- Begin output of /usr/bin/pip install  --upgrade virtualenv ----
           STDOUT: Downloading/unpacking virtualenv
             Running setup.py egg_info for package virtualenv
               /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'entry_points'
                 warnings.warn(msg)
               /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'zip_safe'
                 warnings.warn(msg)
               /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'test_suite'
                 warnings.warn(msg)
               /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'tests_require'
                 warnings.warn(msg)
               usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
                  or: -c --help [cmd1 cmd2 ...]
                  or: -c --help-commands
                  or: -c cmd --help
               
               error: invalid command 'egg_info'
               Complete output from command python setup.py egg_info:
               /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'entry_points'
           
             warnings.warn(msg)
           
           /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'zip_safe'
           
             warnings.warn(msg)
           
           /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'test_suite'
           
             warnings.warn(msg)
           
           /usr/lib64/python2.6/distutils/dist.py:266: UserWarning: Unknown distribution option: 'tests_require'
           
             warnings.warn(msg)
           
           usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
           
              or: -c --help [cmd1 cmd2 ...]
           
              or: -c --help-commands
           
              or: -c cmd --help
           
           
           
           error: invalid command 'egg_info'
           
           ----------------------------------------
           Command python setup.py egg_info failed with error code 1 in /tmp/pip-build-root/virtualenv
           Storing complete log in /root/.pip/pip.log
           STDERR: 
           ---- End output of /usr/bin/pip install  --upgrade virtualenv ----
           Ran /usr/bin/pip install  --upgrade virtualenv returned 1
           
           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/python/providers/pip.rb:155:in `pip_cmd'
           /tmp/kitchen/cache/cookbooks/python/providers/pip.rb:136:in `install_package'
           /tmp/kitchen/cache/cookbooks/python/providers/pip.rb:141:in `upgrade_package'
           /tmp/kitchen/cache/cookbooks/python/providers/pip.rb:60:in `block (2 levels) in class_from_file'
           /tmp/kitchen/cache/cookbooks/python/providers/pip.rb:58:in `block in class_from_file'
           
           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/python/recipes/virtualenv.rb
           
            23: python_pip "virtualenv" do
            24:   action :upgrade
            25:   version node['python']['virtualenv_version']
            26: end
           
           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/python/recipes/virtualenv.rb:23:in `from_file'
           
           python_pip("virtualenv") do
             action [:upgrade]
             retries 0
             retry_delay 2
             guard_interpreter :default
             cookbook_name "python"
             recipe_name "virtualenv"
             package_name "virtualenv"
             options " --upgrade"
             timeout 900
           end
```

My fix was to run the setuptools upgrade twice in recipes/pip.rb. I couldn't override this in a wrapper script because I couldn't trigger anything to run after ::package but before ::pip. I stepped through that process before committing it here, and below was what happened for each setuptools upgrade:

```
First run --
Version: 0.6c11 (before)
Version: 0.6c11 (after)

Second run --
Version: 0.6c11 (before)
Version: 5.7 (after)
```

This loop in the PR shouldn't affect other systems, as it just ensures setuptools is upgraded twice. For whatever reason, pip doesn't do this on its own.