### PR TITLE
Add support for URLs as package_name in providers/pip current_installed_version comparison

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs Python, pip and virtualenv. Includes LWRPs for managing Python packages with `pip` and `virtualenv` isolated Python environments."
-version           "1.4.8"
+version           "1.4.7"
 
 depends           "build-essential"
 depends           "yum-epel"


### PR DESCRIPTION
In case we use an URL (as package_name) for pip we have to filter out 
the real package_name from such an URL (means: We remove all unneeded
parts).

In the next step we can use the extracted package_name as usual too look up and compare with current installed packages. 

Without such a change, the current_installed_version always returns NIL.

Signed-off-by: Martin Wilhelm martin@system4.org
