### PR TITLE
upgrade pip before upgrading setuptools to fix virtualenv install on fai...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,3 +43,4 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil
+default['python']['pip_version'] = nil

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -47,6 +47,11 @@ execute "install-pip" do
   not_if { ::File.exists?(pip_binary) }
 end
 
+python_pip 'pip' do
+  action :upgrade
+  version node['python']['pip_version']
+end
+
 python_pip 'setuptools' do
   action :upgrade
   version node['python']['setuptools_version']


### PR DESCRIPTION
As an alternative to pull request #120 to resolve issue #100 & #111 , I have found that upgrading pip using pip_package prior to attempting to install setuptools resolves the problem.  In keeping with the convention used in the cookbook, I added an attribute to specify a pip version other than latest.