### PR TITLE
parse PiPy for candidate version using yolk

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,8 @@ site :opscode
 
 metadata
 
+cookbook "chef-sugar"
+
 group :integration do
   cookbook "minitest-handler"
   cookbook "apt"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,3 +43,5 @@ default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil
+default['python']['yolk_version'] = nil
+default['python']['yolk_location'] = "#{node['python']['prefix_dir']}/bin/yolk"

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ version           "1.4.7"
 
 depends           "build-essential"
 depends           "yum-epel"
+depends           "chef-sugar"
 
 recipe "python", "Installs python, pip, and virtualenv"
 recipe "python::package", "Installs python using packages."

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -20,7 +20,7 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
-require 'version'
+require 'versionub'
 include Chef::Mixin::ShellOut
 
 def whyrun_supported?
@@ -128,11 +128,13 @@ def candidate_version
       if out.match(/not installed/) then
         new_resource.version||'latest'
       elsif out.match(/#{new_resource.package_name} [\d\.]+ \([\d\.]+\)/) then
-        available_version = Version.new(out.split(' ').last.tr('()',''))
-        if available_version > ( Version.new(new_resource.version) || Version.new('0.0') )
+        available_version = Versionub.parse(out.split(' ').last.tr('()',''))
+        if ! new_resource.version
+          available_version.to_s
+        elsif available_version > Versionub.parse(new_resource.version)
           new_resource.version
         else
-          available_version
+          available_version.to_s
         end
       else
         current_installed_version

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -20,7 +20,7 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
-require 'versionub'
+require 'chef/sugar/core_extensions'
 include Chef::Mixin::ShellOut
 
 def whyrun_supported?
@@ -128,13 +128,13 @@ def candidate_version
       if out.match(/not installed/) then
         new_resource.version||'latest'
       elsif out.match(/#{new_resource.package_name} [\d\.]+ \([\d\.]+\)/) then
-        available_version = Versionub.parse(out.split(' ').last.tr('()',''))
+        available_version = out.split(' ').last.tr('()','')
         if ! new_resource.version
-          available_version.to_s
-        elsif available_version > Versionub.parse(new_resource.version)
+          available_version
+        elsif available_version.satisfies?(">= #{new_resource.version}")
           new_resource.version
         else
-          available_version.to_s
+          available_version
         end
       else
         current_installed_version

--- a/providers/pip.rb
+++ b/providers/pip.rb
@@ -20,6 +20,7 @@
 
 require 'chef/mixin/shell_out'
 require 'chef/mixin/language'
+require 'version'
 include Chef::Mixin::ShellOut
 
 def whyrun_supported?
@@ -117,11 +118,28 @@ def current_installed_version
 end
 
 def candidate_version
+  yolk_path = which_yolk(new_resource)
   @candidate_version ||= begin
-    # `pip search` doesn't return versions yet
-    # `pip list` may be coming soon:
-    # https://bitbucket.org/ianb/pip/issue/197/option-to-show-what-version-would-be
-    new_resource.version||'latest'
+    # if yolk is installed, check if a newer version is available in PyPi
+    # then check if newer version is greater then the version specified by new_resource
+    # return as appropriate
+    if ::File.exists?(yolk_path) then
+      out = shell_out("#{yolk_path} -U #{new_resource.package_name}").stdout
+      if out.match(/not installed/) then
+        new_resource.version||'latest'
+      elsif out.match(/#{new_resource.package_name} [\d\.]+ \([\d\.]+\)/) then
+        available_version = Version.new(out.split(' ').last.tr('()',''))
+        if available_version > ( Version.new(new_resource.version) || Version.new('0.0') )
+          new_resource.version
+        else
+          available_version
+        end
+      else
+        current_installed_version
+      end
+    else
+      new_resource.version||'latest'
+    end
   end
 end
 
@@ -164,5 +182,15 @@ def which_pip(nr)
     node['python']['pip_location']
   else
     'pip'
+  end
+end
+
+def which_yolk(nr)
+  if (nr.respond_to?("virtualenv") && nr.virtualenv)
+    ::File.join(nr.virtualenv,'/bin/yolk')
+  elsif ::File.exists?(node['python']['yolk_location'])
+    node['python']['yolk_location']
+  else
+    'yolk'
   end
 end

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -33,6 +33,10 @@ else
   pip_binary = "/usr/local/bin/pip"
 end
 
+chef_gem 'version' do
+  action :nothing
+end.run_action(:install)
+
 cookbook_file "#{Chef::Config[:file_cache_path]}/get-pip.py" do
   source 'get-pip.py'
   mode "0644"
@@ -45,6 +49,11 @@ execute "install-pip" do
   #{node['python']['binary']} get-pip.py
   EOF
   not_if { ::File.exists?(pip_binary) }
+end
+
+python_pip 'yolk' do
+  action :upgrade
+  version node['python']['yolk_version']
 end
 
 python_pip 'setuptools' do

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -33,7 +33,7 @@ else
   pip_binary = "/usr/local/bin/pip"
 end
 
-chef_gem 'version' do
+chef_gem 'versionub' do
   action :nothing
 end.run_action(:install)
 

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -33,10 +33,6 @@ else
   pip_binary = "/usr/local/bin/pip"
 end
 
-chef_gem 'versionub' do
-  action :nothing
-end.run_action(:install)
-
 cookbook_file "#{Chef::Config[:file_cache_path]}/get-pip.py" do
   source 'get-pip.py'
   mode "0644"


### PR DESCRIPTION
Currently, the python_pip LWRP will execute a `pip install...` every chef run if the action is set to :upgrade.  This patch will amend that behavior by installing the yolk egg and using it to query PyPi to see if there is a newer version of an egg available.  This will prevent the resource from returning as updated if the package is already the latest/specified version.