### PR TITLE
Adds ability to override the installed version of PIP

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,8 @@ default['python']['configure_options'] = %W{--prefix=#{node['python']['prefix_di
 default['python']['make_options'] = %W{install}
 
 default['python']['pip_location'] = "#{node['python']['prefix_dir']}/bin/pip"
+default['python']['pip_version'] = nil
+
 default['python']['virtualenv_location'] = "#{node['python']['prefix_dir']}/bin/virtualenv"
 default['python']['setuptools_version'] = nil # defaults to latest
 default['python']['virtualenv_version'] = nil

--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -47,6 +47,12 @@ execute "install-pip" do
   not_if { ::File.exists?(pip_binary) }
 end
 
+# once pip is installed we can set it to a configured version
+python_pip 'pip' do
+  action :upgrade
+  version node['python']['pip_version']
+end
+
 python_pip 'setuptools' do
   action :upgrade
   version node['python']['setuptools_version']


### PR DESCRIPTION
We have an environment in which controlling the versions of all software installed on it is of critical importance.  As such we needed a way to tell Chef to install the version of PIP we need rather than the latest version. This updates the pip install recipe to allow it to use a defined version.

I am working on getting a testing env working but wanted to get this posted over for feedback.