### PR TITLE
Removing ubuntu-12.10 from .kitchen.yml

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,11 +4,6 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
-- name: ubuntu-12.10
-  driver_config:
-    box: opscode-ubuntu-12.10
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.10_provisionerless.box
-  run_list: ["recipe[apt]"]
 
 - name: ubuntu-12.04
   driver_config:


### PR DESCRIPTION
Ubuntu is no longer supporting 12.10 so apt-get update is failing, which
in turns makes the kitchen converge fail.