### PR TITLE
Fixed a typo in test_pip.rb

### DIFF
--- a/test/cookbooks/python_test/recipes/test_pip.rb
+++ b/test/cookbooks/python_test/recipes/test_pip.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Hugo Lopes Tavares <hltbra@gmail.com>
 # Cookbook Name:: python
-# Recipe:: test_virtualenv
+# Recipe:: test_pip
 #
 # Copyright 2013, Heavy Water Operations, LLC.
 # Copyright 2014, Yipit, Inc.


### PR DESCRIPTION
I noticed the recipes name was copied from test_virtualenv.rb