### PR TITLE
Add ubuntu-14.04 to .kitchen.yml platform

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,9 @@ driver_config:
   require_chef_omnibus: true
 
 platforms:
+- name: ubuntu-14.04
+  run_list: ["recipe[apt]"]
+
 - name: ubuntu-12.10
   driver_config:
     box: opscode-ubuntu-12.10

--- a/test/cookbooks/python_test/recipes/test_exert.rb
+++ b/test/cookbooks/python_test/recipes/test_exert.rb
@@ -30,6 +30,6 @@ python_pip "boto" do
   virtualenv "#{Chef::Config[:file_cache_path]}/virtualenv"
 end
 
-python_pip "psutil" do
+python_pip "should_dsl" do
   action :install
 end


### PR DESCRIPTION
Adding ubuntu-14.04 made test_exec fail since there is no gcc in opscode-ubuntu-14.04 VM and 'psutil' depends on it. So
I changed test_exec.rb to install 'should_dsl' instead of 'psutil'.