### PR TITLE
wget cannot redirect http to https

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,7 @@ end
 
 default['python']['binary'] = "#{node['python']['prefix_dir']}/bin/python"
 
-default['python']['url'] = 'http://www.python.org/ftp/python'
+default['python']['url'] = 'https://www.python.org/ftp/python'
 default['python']['version'] = '2.7.7'
 default['python']['checksum'] = '7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42'
 default['python']['configure_options'] = %W{--prefix=#{node['python']['prefix_dir']}}


### PR DESCRIPTION
Because http://www.python.org redirect to https://www.python.org, my Centos 6.3 download only html file by this command. 
wget http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tar.bz2

It should change to https://www.python.org.