### PR TITLE
fix pip executable location for Ubuntu and Debian

### DIFF
--- a/recipes/pip.rb
+++ b/recipes/pip.rb
@@ -25,7 +25,7 @@
 
 if node['python']['install_method'] == 'source'
   pip_binary = "#{node['python']['prefix_dir']}/bin/pip"
-elsif platform_family?("rhel", "fedora")
+elsif platform_family?("rhel", "fedora", "debian", "ubuntu")
   pip_binary = "/usr/bin/pip"
 elsif platform_family?("smartos")
   pip_binary = "/opt/local/bin/pip"


### PR DESCRIPTION
Running the Python recipe on a Debian (or Ubuntu) node is more complicated than it needs to be because the path to the pip binary for these distro families is not included in the decision tree.

Changes in pip' source due to OpenSSL v.3 being heavily deprecated lead to a build failure in Debian. The issue this change addresses results in the python recipe trying to build pip even when pip has already been installed with a deb pkg.

This change adds debian and ubuntu families' configuration to use the correct path of /usr/bin/pip